### PR TITLE
SQ-22631 Ajuste - No upload manual de TikTok, não precisa ser obrigatório o link do vídeo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sq-libs",
-  "version": "2212.1.5",
+  "version": "2212.1.6",
   "description": "Projeto que agrupa libs privadas da organização Squid",
   "main": "index.js",
   "scripts": {

--- a/sq-media-mapping/src/map-tiktok-media.js
+++ b/sq-media-mapping/src/map-tiktok-media.js
@@ -54,6 +54,13 @@ function mapTiktokMediaToSquidMedia (tiktokMedia) {
         height: get(tiktokMedia, 'height', 480)
       }
     },
+    videos: {
+      resolucaoPadrao: {
+        url: get(tiktokMedia, 'media_url', ''),
+        width: get(tiktokMedia, 'width', 540),
+        height: get(tiktokMedia, 'height', 480)
+      }
+    },
     metadados: {
       statistics: {
         viewCount: parseInt(get(tiktokMedia, 'view_count', 0), 10),


### PR DESCRIPTION
TASK: https://duopana.myjetbrains.com/youtrack/agiles/115-13/current?issue=SQ-22631

Evidência de teste:
Este é um endpoint que faz uso dessa lib.
![image](https://github.com/squidit/sq-libs/assets/59963452/50645f1a-1d6c-460a-a9d5-acf71666ec4c)
Essa é a mídia upada - https://squid-apis-portal-stg--pr3171-us-sq-21743-upload-s-mc2w22jh.web.app/campaigns/64529f117c99dfbcb3795e69/contents?tab=Videos&idMedia=64a6fd05518968a66001387d

Doc: https://github.com/squidit/sq-libs#readme