### PR TITLE
add duration only to image_story

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sq-libs",
-  "version": "2401.2.0",
+  "version": "2401.2.1",
   "description": "Projeto que agrupa libs privadas da organização Squid",
   "main": "index.js",
   "scripts": {

--- a/sq-media-mapping/package.json
+++ b/sq-media-mapping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid-media-mapping",
-  "version": "2401.1.0",
+  "version": "2401.2.1",
   "description": "Mapping functions from whatever to media",
   "main": "index.js",
   "scripts": {

--- a/sq-media-mapping/src/map-story-media.js
+++ b/sq-media-mapping/src/map-story-media.js
@@ -20,7 +20,6 @@ function mapStoryMediaToSquidMedia (storyMedia) {
     lastUpdate: new Date(),
     legenda: get(storyMedia, 'caption', ''),
     detection: get(storyMedia, 'detection', null),
-    duration: get(storyMedia, 'duration', 15),
     usuario: {
       id: `instagram|${get(storyMedia, 'user.ig_id')}`,
       username: get(storyMedia, 'user.username', ''),
@@ -61,6 +60,7 @@ function mapStoryMediaToSquidMedia (storyMedia) {
       }
     }
   } else if (media.tipo === 'imagem_stories') {
+    media.duration = 15
     media.imagens = {
       resolucaoPadrao: {
         url: get(storyMedia, 'media_url', ''),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified the default duration setting for images in story media mapping to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->